### PR TITLE
[interval_tree]: ExactMatch change end address computation method to not miss a free slot.

### DIFF
--- a/src/address_allocator.rs
+++ b/src/address_allocator.rs
@@ -76,6 +76,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_regression_exact_match_length_check() {
+        let mut pool = AddressAllocator::new(0x0, 0x2000).unwrap();
+        let res = pool
+            .allocate(0x1000, 0x1000, AllocPolicy::ExactMatch(0x1000))
+            .unwrap();
+        assert_eq!(res, Range::new(0x1000, 0x1FFF).unwrap());
+        let res = pool
+            .allocate(0x1000, 0x1000, AllocPolicy::ExactMatch(0x0))
+            .unwrap();
+        assert_eq!(res, Range::new(0x0, 0x0FFF).unwrap());
+    }
+
+    #[test]
     fn test_new_fails_overflow() {
         assert_eq!(
             AddressAllocator::new(u64::max_value(), 0x100).unwrap_err(),

--- a/src/allocation_engine/interval_tree.rs
+++ b/src/allocation_engine/interval_tree.rs
@@ -340,14 +340,15 @@ impl InnerNode {
                     .search_superset(&Range::new(start_address, start_address + 1)?)
                     .ok_or(Error::ResourceNotAvailable)?;
                 let end_address = start_address
-                    .checked_add(constraint.size())
+                    .checked_add(constraint.size().checked_sub(1).ok_or(Error::Underflow)?)
                     .ok_or(Error::Overflow)?;
                 // We should check that starting from the desired address the
                 // whole memory slot will fit in the selected node.
-                if end_address > node.key.end() {
+                let range = Range::new(start_address, end_address)?;
+                if !node.key.contains(&range) {
                     return Err(Error::ResourceNotAvailable);
                 }
-                Ok((node, Range::new(start_address, end_address)?))
+                Ok((node, range))
             }
         }
     }

--- a/src/id_allocator.rs
+++ b/src/id_allocator.rs
@@ -50,7 +50,7 @@ impl IdAllocator {
         self.range_base <= id && id <= self.range_end
     }
 
-    /// Allocate an ID from the managed ranged.
+    /// Allocate an ID from the managed range.
     /// We first try to reuse one of the IDs released before. If there is no
     /// ID to reuse we return the next available one from the managed range.
     pub fn allocate_id(&mut self) -> Result<u32> {


### PR DESCRIPTION
When computing the end address in the `ExactMatch` we are looking for ranges greater than what was actually requested, this is caused by the fact that the ranges are inclusive on the left side so given a range [0x0 - 0x0FFF] that has the length 0x1000 and a allocation request with allocation policy `ExactMatch(0)` and size 0x1000 we will miss the said range because [here](https://github.com/rust-vmm/vm-allocator/blob/ce56e5c5db333d728547b6a990f916b46cdbb661/src/allocation_engine/interval_tree.rs#L342) the computed end address would be 0x1000 that does not belong to [0x0 - 0x0FFF] thus ignoring a valid range.

### Summary of the PR

* Updated the way we compute the end address in `AllocPolicy::ExactMatch` case, to reflect the fact that the Range is inclusive on the left side so the end address should be `start_address + size - 1`.
* Added regression test to check that we are not missing any available slot because of the off by one that was present before due to error described above
* Renamed `Range` structure to `RangeInclusive` to reflect that both ends of the range are inclusive as opposed to the std::ops::Range implementation.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
