### PR TITLE
replace deprecated std::u64::MAX with u64::MAX

### DIFF
--- a/src/allocation_engine/interval_tree.rs
+++ b/src/allocation_engine/interval_tree.rs
@@ -577,7 +577,7 @@ impl IntervalTree {
         }
         // If the deleted range did not end at u64::MAX we try to find ranges
         // that are placed to its left so we can merge them together.
-        if range.end() < std::u64::MAX {
+        if range.end() < u64::MAX {
             if let Some(node) = self.search_superset(&Range::new(range.end(), range.end() + 1)?) {
                 if node.node_state == NodeState::Free {
                     range = Range::new(range.start(), node.key.end())?;


### PR DESCRIPTION
Signed-off-by: Victor Chiriac <voidbuf@gmail.com>

### Summary of the PR

This is a fix for #22 which replaces the use of the deprecated `std::u64::MAX`
constant with the non-deprecated, now preferred `u64::MAX`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test. (small fix, does not require new tests and `cargo test` passes)
- [x] Any newly added `unsafe` code is properly documented. (no unsafe code added)
