### PR TITLE
newtype pattern

### DIFF
--- a/src/address_allocator.rs
+++ b/src/address_allocator.rs
@@ -41,7 +41,7 @@ impl AddressAllocator {
             .ok_or(Error::Overflow)?;
         let aux_range = RangeInclusive::new(base, end)?;
         Ok(AddressAllocator {
-            address_space: aux_range,
+            address_space: aux_range.clone(),
             interval_tree: IntervalTree::new(aux_range),
         })
     }


### PR DESCRIPTION
### Summary of the PR

Implementing [the newtype pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html) for the [`vm_allocator::RangeInclusive`](https://docs.rs/vm-allocator/latest/vm_allocator/struct.RangeInclusive.html).

The newtype pattern is the typical approach to implementing different functionality on top of identical data, in this case we are implementing functionality on top of data identical to `std::ops::RangeInclusive`.

With the inability to now derive `PartialOrd` we write an explicit implantation that can be better understood without requiring prerequisite knowledge about how the derive macro for `PartialOrd` specifically works.

And implementing `Deref` allows easy access to the underlying `std::ops::RangeInclusive<u64>` removing the need to re-implement `start()` and `end()`. `Deref` could potentially introduce ambiguity between the function calls such as `std::ops::RangeInclusive::new()` and `vm_allocator::RangeInclusive::new()`, and `std::ops::RangeInclusive::contains()` and `vm_allocator::RangeInclusive::contains()` but it will always prefer the `vm_allocator::RangeInclusive` implementations (as can be seen in all tests continuing to pass) so this ambiguity would only have an affect upon readability. Although on this point I do not have a strong opinion and if you consider this ambiguity to be too much I could remove this.

Since now we cannot derive `Copy` it does add additional overhead of requiring explicit clones throughout the code, although this makes no functional difference.

I believe this change both brings usage more inline with recommended Rust patterns and increases the readability and explicitness of the code while introducing no meaningful functionality changes.

### Requirements

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
