### PR TITLE
Use std::ops::RangeInclusive for IdAllocator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! impl DeviceManager {
 //!     pub fn new() -> Result<Self> {
 //!         Ok(DeviceManager {
-//!             id_allocator: IdAllocator::new(0, 100)?,
+//!             id_allocator: IdAllocator::new(0..=100)?,
 //!             mmio_allocator: AddressAllocator::new(MMIO_MEM_START, MEM_32BIT_GAP_SIZE)?,
 //!             slots: HashMap::new(),
 //!         })


### PR DESCRIPTION
### Summary of the PR

Instead of holding 2 `u32`s within `IdAllocator` to simulate a range, it could have a single value that is a range. This allows for easier construction, more explicit code and better readability.

This does introduce the need to dereference when getting the start and end of the range while somewhat awkward I don't believe this has any notable functional affect. This could be mitigated if `std::ops::Range` was used instead. I went with `std::ops::RangeInclusive` in this since it most closely resembles current usage and doesn't require many changes. I believe the change to `std::ops::Range` if it occurs should be in another commit to minimize too large changes in one commit/pr.

### Requirements

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
