### PR TITLE
Unchecked implementations for IdAllocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ edition = "2018"
 [dependencies]
 libc = ">=0.2.39"
 thiserror = "1.0"
+
+[dev-dependencies]
+criterion = "0.3.5"
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,57 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use vm_allocator::*;
+
+const MIN: u32 = 0;
+const MAX: u32 = 100;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("IdAllocator::new", |b| {
+        b.iter(|| IdAllocator::new(MIN, MAX).unwrap())
+    });
+    c.bench_function("IdAllocator::new_unchecked", |b| {
+        b.iter(|| IdAllocator::new_unchecked(MIN, MAX))
+    });
+    c.bench_function("IdAllocator::allocate_id", move |b| {
+        b.iter_with_setup(
+            || IdAllocator::new(MIN, MAX).unwrap(),
+            |mut allocator| {
+                allocator.allocate_id().unwrap();
+            },
+        )
+    });
+    c.bench_function("IdAllocator::allocate_id_unchecked", |b| {
+        b.iter_with_setup(
+            || IdAllocator::new_unchecked(MIN, MAX),
+            |mut allocator| {
+                allocator.allocate_id_unchecked();
+            },
+        )
+    });
+    c.bench_function("IdAllocator::free_id", |b| {
+        b.iter_with_setup(
+            || {
+                let mut allocator = IdAllocator::new(MIN, MAX).unwrap();
+                allocator.allocate_id().unwrap();
+                allocator
+            },
+            |mut allocator| {
+                allocator.free_id(MIN).unwrap();
+            },
+        )
+    });
+    c.bench_function("IdAllocator::free_id_unchecked", |b| {
+        b.iter_with_setup(
+            || {
+                let mut allocator = IdAllocator::new_unchecked(MIN, MAX);
+                allocator.allocate_id_unchecked();
+                allocator
+            },
+            |mut allocator| {
+                allocator.free_id_unchecked(MIN);
+            },
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
### Summary of the PR

I have added unchecked implementations for `IdAllocator` ([`new_unchecked`](https://github.com/rust-vmm/vm-allocator/compare/main...JonathanWoollett-Light:id-allocator-unchecked?expand=1#diff-2b83e3b1a6a58e439c8b03c94bce0970d976ee55947654a11e4599666c1784aaR47-R57), [`allocate_id_unchecked`](https://github.com/rust-vmm/vm-allocator/compare/main...JonathanWoollett-Light:id-allocator-unchecked?expand=1#diff-2b83e3b1a6a58e439c8b03c94bce0970d976ee55947654a11e4599666c1784aaR101-R117) and [`free_id_unchecked`](https://github.com/rust-vmm/vm-allocator/compare/main...JonathanWoollett-Light:id-allocator-unchecked?expand=1#diff-2b83e3b1a6a58e439c8b03c94bce0970d976ee55947654a11e4599666c1784aaR142-R147) corresponding to the existing implementations `new`, `allocate_id` and `free_id` respectively). These unchecked implementations allow skipping certain checks offering better performance.

It is common to encounter circumstance where we can can guarantee that a given `Result` will always be `Ok` and thus a given `unwrap()` will never panic (often when using constants). In this circumstances it can be beneficial to avoid unnecessary checks, a couple examples from the standard library are [`i32::unchecked_add`](https://doc.rust-lang.org/std/primitive.i32.html#method.unchecked_add) and [`slice::get_unchecked`](https://doc.rust-lang.org/std/primitive.slice.html#method.get_unchecked).

In implementing these unchecked functions which mirror existing functions I have also made minor stylistic changes to the existing functions such that they better match each other. I have also mirrored all tests for the unchecked variants.

If it where already present in the project I would have added benchmarks to evaluate the performance of the checked vs unchecked variants, although I felt including a large dependency such as [criterion](https://crates.io/crates/criterion) (even as a `dev-dependency`) would warrant its own pr and should introduce benchmarks for most functionality in the library rather than a small subset.

---


The specific use case that brought up this suggestion was when using constants for a given range e.g.
```rust
pub const IRQ_MAX: u32 = 128;
/// First usable interrupt on aarch64.
pub const IRQ_BASE: u32 = 32;
```
When calling `IdAllocator::new(IRQ_BASE,IRQ_MAX).unwrap()` we are doing unnecessary checks within `IdAllocator::new`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
