### PR TITLE
Added serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 [dependencies]
 libc = "0.2.39"
 thiserror = "2.0"
+serde = { version = "1.0.137", optional = true, features = ["derive"] }

--- a/src/address_allocator.rs
+++ b/src/address_allocator.rs
@@ -22,6 +22,7 @@ use crate::{AllocPolicy, Constraint, Error, RangeInclusive, Result};
 /// The `AddressAllocator` manages an address space by exporting functionality to reserve and
 /// free address ranges based on a user defined [Allocation Policy](enum.AllocPolicy.html).
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddressAllocator {
     // Address space that we want to manage.
     address_space: RangeInclusive,

--- a/src/allocation_engine/interval_tree.rs
+++ b/src/allocation_engine/interval_tree.rs
@@ -41,6 +41,7 @@ pub fn align_up(address: u64, alignment: u64) -> Result<u64> {
 /// - Allocated -> Free: IntervalTree::free()
 /// - * -> None: IntervalTree::delete()
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NodeState {
     /// Node is free.
     Free,
@@ -56,6 +57,7 @@ impl NodeState {
 
 /// Internal tree node to implement interval tree.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct InnerNode {
     /// Interval handled by this node.
     key: RangeInclusive,
@@ -490,6 +492,7 @@ fn height(node: &Option<Box<InnerNode>>) -> u64 {
 
 /// An interval tree implementation specialized for VMM memory slots management.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IntervalTree {
     root: Option<Box<InnerNode>>,
 }

--- a/src/id_allocator.rs
+++ b/src/id_allocator.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeSet;
 // O(logN) compared to Vec for example, another benefit is that the entries
 // are sorted so we will always use the first available ID.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IdAllocator {
     // Beginning of the range of IDs that we want to manage.
     range_base: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// ```
 // This structure represents the key of the Node object in the interval tree implementation.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Hash, Ord, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RangeInclusive {
     /// Lower boundary of the interval.
     start: u64,


### PR DESCRIPTION
### Summary of the PR

Added [serde](https://serde.rs/) support via a feature that derives [`Serialize`](https://docs.serde.rs/serde/trait.Serialize.html) and [`Deserialize`](https://docs.serde.rs/serde/trait.Deserialize.html) for [`IdAllocator`](https://docs.rs/vm-allocator/latest/vm_allocator/struct.IdAllocator.html) and [`AddressAllocator`](https://docs.rs/vm-allocator/latest/vm_allocator/struct.AddressAllocator.html) (and contained types). This should in the future allow exact restoration of `IdAllocator` and `AddressAllocator` from a stored version. I would suggest it is just best practice to derive `Serialize` and `Deserialize` for crate public types (like `Debug`). This change should have no affect (including compile time) to the existing code base.

You may wish to change the documentation to build with `cargo rustdoc --all-features` but I was unsure what changes to make here and how to annotate them.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
