### PR TITLE
Range inclusive size 1

### DIFF
--- a/src/address_allocator.rs
+++ b/src/address_allocator.rs
@@ -245,6 +245,19 @@ mod tests {
     }
 
     #[test]
+    fn test_allow_range_size_one_left() {
+        let mut pool = AddressAllocator::new(1, 1000).unwrap();
+        assert_eq!(
+            pool.allocate(10, 2, AllocPolicy::FirstMatch).unwrap(),
+            RangeInclusive::new(2, 11).unwrap()
+        );
+        assert_eq!(
+            pool.allocate(1, 1, AllocPolicy::FirstMatch).unwrap(),
+            RangeInclusive::new(1, 1).unwrap()
+        );
+    }
+
+    #[test]
     fn test_allocate_address_fail_free_and_realloc() {
         let mut pool = AddressAllocator::new(0x0, 0x1000).unwrap();
         //First allocation fails

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ impl RangeInclusive {
         // The length of the interval [0, u64::MAX] is u64::MAX + 1 which does
         // not fit in a u64::MAX, hence we return `Error::InvalidRange` when
         // there is an attempt to use that range.
-        if start >= end || (start == 0 && end == u64::MAX) {
+        if start > end || (start == 0 && end == u64::MAX) {
             return Err(Error::InvalidRange(start, end));
         }
         Ok(RangeInclusive { start, end })
@@ -311,8 +311,8 @@ mod tests {
             Error::InvalidRange(2, 1)
         );
         assert_eq!(
-            RangeInclusive::new(1, 1).unwrap_err(),
-            Error::InvalidRange(1, 1)
+            RangeInclusive::new(0, u64::MAX).unwrap_err(),
+            Error::InvalidRange(0, u64::MAX)
         );
     }
 


### PR DESCRIPTION
### Summary of the PR

Fixes #42 
Allows creation of intervals where the start is equal with the end of the interval. This could also be the first PR from a series of changes that could enable use of interval_tree allocation engine for IdAllocator.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
