### PR TITLE
Derive Eq where PartialEq is derived

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ impl Constraint {
 }
 
 /// Policy for resource allocation.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AllocPolicy {
     /// Allocate the first matched entry.
     FirstMatch,


### PR DESCRIPTION
### Summary of the PR

This is required by clippy for rustc 1.63.
Unblocks https://github.com/rust-vmm/vm-allocator/pull/45

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
