### PR TITLE
dependabot: disable automatic rebases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
   schedule: 
     interval: weekly
   open-pull-requests-limit: 10
+  rebase-strategy: "disabled"


### PR DESCRIPTION
Follow up to https://github.com/rust-vmm/vm-allocator/pull/56#discussion_r1164025645

The idea is that since two dependabot PRs shouldn't conflict (since they modify separate dependencies), we should be able to use the "Update Branch" button on the GitHub UI to rebase its PRs. This preserves approvals, whereas dependabot rebasing for us would invalidate them due to a force-push. Having to press the "Update Branch" button is less work than getting re-approvals.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
