### PR TITLE
Add available() API in AddressAllocator #94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Upcoming version
 
 ### Added
+
+- Added `available()` API in `AddressAllocator` to allow
+  getting the available memories after `allocate/free()`s
+
 ### Changed
 ### Fixed
 ### Removed


### PR DESCRIPTION
### Summary of the PR

bit dumb here, but I thought it should be a common use case to get the rest available memories in `AddressAllocator`, while i don't see a way on how to get this info today.
Or there is already a way to get this info from allocator and somehow i missed it? (please lmk)

So add a new private var `available`
* init it w/ the total memory space size
* inc/dec it when `allocate/free()`
* expose it in a new public API `available()`

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.