### PR TITLE
address_allocator: add methods to get base and size of region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Upcoming version
 
 ### Added
+
+- [[#40]](https://github.com/rust-vmm/vm-allocator/pull/40): Added serde
+  support for IdAllocator and AddressAllocator.
+- [[#99]](https://github.com/rust-vmm/vm-allocator/pull/99): Added APIs to
+  get the base address and size of an AddressAllocator.
+
 ### Changed
 ### Fixed
 ### Removed

--- a/src/address_allocator.rs
+++ b/src/address_allocator.rs
@@ -72,6 +72,16 @@ impl AddressAllocator {
     pub fn free(&mut self, key: &RangeInclusive) -> Result<()> {
         self.interval_tree.free(key)
     }
+
+    /// First address of the allocator.
+    pub fn base(&self) -> u64 {
+        self.address_space.start()
+    }
+
+    /// Last address of the allocator.
+    pub fn end(&self) -> u64 {
+        self.address_space.end()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Summary of the PR

Add methods that allow to get info about the base address and size of the region that an AddressAllocator is handling.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
