### PR TITLE
id-allocator: fix double-alloc and add `is_allocated` public fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@
 ### Added
 
 - Support for no_std environments.
+- [[#120]](https://github.com/rust-vmm/vm-allocator/pull/120): `IdAllocator::is_allocated` to query whether a given id is currently
+  allocated.
 
 ### Changed
 ### Fixed
+
+- [[#120]](https://github.com/rust-vmm/vm-allocator/pull/120): `IdAllocator::free_id` incorrectly accepted freeing `next_id` (an id that was
+  never allocated), which could lead to the same id being allocated twice.
+
 ### Removed
 ### Deprecated
 

--- a/src/id_allocator.rs
+++ b/src/id_allocator.rs
@@ -84,7 +84,7 @@ impl IdAllocator {
             return Err(Error::OutOfRange(id));
         }
         if let Some(next_id) = self.next_id {
-            if next_id < id {
+            if next_id <= id {
                 return Err(Error::NeverAllocated(id));
             }
         }
@@ -170,6 +170,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_free_id_never_allocated_boundary() {
+        let mut allocator = IdAllocator::new(5, 23).unwrap();
+
+        assert_eq!(allocator.next_id.unwrap(), 5);
+        assert_eq!(allocator.free_id(5).unwrap_err(), Error::NeverAllocated(5));
+        assert_eq!(allocator.freed_ids.len(), 0);
+
+        for _ in 0..3 {
+            allocator.allocate_id().unwrap();
+        }
+        assert_eq!(allocator.next_id.unwrap(), 8);
+        assert_eq!(allocator.free_id(8).unwrap_err(), Error::NeverAllocated(8));
+        assert_eq!(allocator.freed_ids.len(), 0);
+    }
     #[test]
     fn test_id_sanity_checks() {
         let legacy_irq_allocator = IdAllocator::new(5, 23).unwrap();

--- a/src/id_allocator.rs
+++ b/src/id_allocator.rs
@@ -76,6 +76,25 @@ impl IdAllocator {
         Err(Error::Overflow)
     }
 
+    /// Returns `true` if `id` is currently allocated from the managed range.
+    ///
+    /// An id is considered allocated if it has been handed out by
+    /// [`allocate_id`](Self::allocate_id) and not since released by
+    /// [`free_id`](Self::free_id). Ids outside the managed range are never
+    /// allocated.
+    pub fn is_allocated(&self, id: u32) -> bool {
+        if !self.id_in_range(id) || self.freed_ids.contains(&id) {
+            return false;
+        }
+        // An id is allocated iff it has already been handed out. `next_id` is
+        // the next id to hand out; `None` means the whole range has been
+        // handed out.
+        match self.next_id {
+            Some(next) => id < next,
+            None => true,
+        }
+    }
+
     /// Frees an id from the managed range.
     pub fn free_id(&mut self, id: u32) -> Result<u32> {
         // Check if the id belongs to the managed range and if it was not
@@ -185,6 +204,66 @@ mod tests {
         assert_eq!(allocator.free_id(8).unwrap_err(), Error::NeverAllocated(8));
         assert_eq!(allocator.freed_ids.len(), 0);
     }
+
+    #[test]
+    fn test_is_allocated() {
+        let mut allocator = IdAllocator::new(5, 23).unwrap();
+
+        assert!(!allocator.is_allocated(4));
+        assert!(!allocator.is_allocated(24));
+
+        assert!(!allocator.is_allocated(10));
+
+        let id = allocator.allocate_id().unwrap();
+        assert_eq!(id, 5);
+        assert!(allocator.is_allocated(5));
+        assert!(!allocator.is_allocated(6));
+
+        allocator.free_id(5).unwrap();
+        assert!(!allocator.is_allocated(5));
+
+        let id = allocator.allocate_id().unwrap();
+        assert_eq!(id, 5);
+        assert!(allocator.is_allocated(5));
+    }
+
+    #[test]
+    fn test_is_allocated_full_range() {
+        let mut allocator = IdAllocator::new(u32::MAX - 1, u32::MAX).unwrap();
+
+        assert!(!allocator.is_allocated(u32::MAX - 1));
+        assert!(!allocator.is_allocated(u32::MAX));
+
+        assert_eq!(allocator.allocate_id().unwrap(), u32::MAX - 1);
+        assert!(allocator.is_allocated(u32::MAX - 1));
+        assert!(!allocator.is_allocated(u32::MAX));
+
+        assert_eq!(allocator.allocate_id().unwrap(), u32::MAX);
+        assert!(allocator.next_id.is_none());
+        assert!(allocator.is_allocated(u32::MAX));
+
+        allocator.free_id(u32::MAX).unwrap();
+        assert!(!allocator.is_allocated(u32::MAX));
+        assert!(allocator.is_allocated(u32::MAX - 1));
+    }
+
+    #[test]
+    fn test_is_allocated_with_freed() {
+        let mut allocator = IdAllocator::new(5, 23).unwrap();
+        allocator.allocate_id().unwrap();
+        allocator.allocate_id().unwrap();
+
+        assert_eq!(allocator.next_id, Some(7));
+
+        assert!(allocator.is_allocated(6));
+        assert!(!allocator.is_allocated(7));
+
+        allocator.free_id(5).unwrap();
+        assert!(!allocator.is_allocated(5));
+        assert!(allocator.is_allocated(6));
+        assert!(!allocator.is_allocated(7));
+    }
+
     #[test]
     fn test_id_sanity_checks() {
         let legacy_irq_allocator = IdAllocator::new(5, 23).unwrap();


### PR DESCRIPTION
- Fix an off-by-one error in free_id that could allow for ids to be double allocated
- Add new `is_allocated` method, so that implementing programs can query whether an id is currently allocated or not
- Update changelog accordingly

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
